### PR TITLE
Ensure shell script checkout with Linux eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Default
+* text=auto !eol
+
+# Scripts
+*.sh text eol=lf


### PR DESCRIPTION
On Windows machines it is easy to accidentally clone the repo via the command-line or GUI client on the main OS. This will cause `.sh` files to be checked out using CRLF line endings, which will break running the script via WSL later.

The error messages are cryptic and overall it is quite difficult to debug, so it is probably best we just enforce that all `.sh` are checked out with LF line endings no matter the OS.